### PR TITLE
Fixes for musl support

### DIFF
--- a/os/os.hpp
+++ b/os/os.hpp
@@ -29,11 +29,16 @@
 
 #if defined(__linux__)
 #include <sched.h>
+#include <libgen.h>
 #endif
 
 #ifdef _WIN32
 #include <Basetsd.h>  // For KAFFINITY
 #endif                // _WIN32
+
+#ifndef __cpu_mask
+typedef unsigned long __cpu_mask;
+#endif
 
 // Smallest supported VM page size.
 #define MIN_PAGE_SHIFT 12


### PR DESCRIPTION
For the pthread changes, I followed the suggestion from https://www.openwall.com/lists/musl/2015/05/08/24 to set thread affinity after `pthread_create`.