### PR TITLE
RTC options: don't split quoted sections of string values

### DIFF
--- a/compiler/lib/utils/options.cpp
+++ b/compiler/lib/utils/options.cpp
@@ -614,25 +614,25 @@ getOptionDesc(std::string& options, size_t StartPos, bool IsShortForm,
              return -1;
          }
 
-         if ((OPTION_type(od) == OT_CSTRING) &&
-              options.at(pos) == '"') {
+         if (OPTION_type(od) == OT_CSTRING) {
+             /* Handle any quoted sections within string value */
              size_t sz = options.size();
-             if ((pos+1) >= sz) {
-                 return -1;
-             }
-             /* Handle quoted string value */
-             ePos = options.find('"', pos+1);
-             if (ePos == std::string::npos) {
-                 return -1;
+             bool quoted = false;
+             ePos = pos;
+
+             while (ePos < sz) {
+                 char c = options.at(ePos);
+                 if (c == '"') {
+                     quoted = !quoted;
+                 } else if (c == ' ' && !quoted) {
+                     break;
+                 }
+                 ++ePos;
              }
 
-             /* Advance ePos to the next position or npos */
-             if (ePos+1 < sz) {
-                 ++ePos;
-                 if (options.at(ePos) != ' ') {
-                     return -1;
-                 }
-             } else {
+             if (quoted) {
+                 return -1; // closing quote is missing
+             } else if (ePos == sz) {
                  ePos = std::string::npos;
              }
          } else {


### PR DESCRIPTION
This PR changes the splitting logic for runtime-compiler (RTC) options of type `OT_CSTRING` so that any spaces within double-quoted sections are not treated as the split point.

This allows for passing in option values with quoted sections such as include paths that include spaces, allowing projects using ROCm run-time compilation to be more robust if the user's environment has paths with spaces.

As an example, previously the option string: `-I INCLUDE_PATH="/path/to/some project/include"` would result in a parsed option value of `-IINCLUDE_PATH="/path/to/some` and then an option parsing error on the remaining `project/include` section.  This problem occurs even if the entire option value is quoted, e.g. `-I "INCLUDE_PATH=/path/to/some project/include"` since the splitting logic (in compiler/lib/utils/options.cpp:getOptionDesc()) was not keeping track of quoted sections.

After this PR the parsed option value will be as desired: `-IINCLUDE_PATH="/path/to/some project/include"` meaning the quoted section is preserved and passed to `clang`.

The new quote handling works as a loop until it finds an unquoted space, meaning it can handle multiple quoted sections in the input string. Currently no attempt has been made to handle escaped quotes/spaces.

I've tested this with a stripped down version of the code in the compiler/libs/utils directory but ran into problems getting a full ROCm installation built from source, and so currently I'm unable to fully test.