### PR TITLE
Fix AMD CoMGR loading

### DIFF
--- a/device/comgrctx.cpp
+++ b/device/comgrctx.cpp
@@ -34,7 +34,7 @@ bool Comgr::LoadLib() {
   static constexpr const char* ComgrLibName =
     LP64_SWITCH(WINDOWS_SWITCH("amd_comgr32.dll", "libamd_comgr32.so.2"),
                 WINDOWS_SWITCH("amd_comgr.dll", "libamd_comgr.so.2"));
-  cep_.handle = Os::loadLibrary(ComgrLibName);
+  cep_.handle = Os::loadLibrary(ComgrLibName, /*global*/true);
   if (nullptr == cep_.handle) {
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "Failed to load COMGR library.");
     return false;

--- a/os/os.cpp
+++ b/os/os.cpp
@@ -37,7 +37,7 @@
 
 namespace amd {
 
-void* Os::loadLibrary(const char* libraryname) {
+void* Os::loadLibrary(const char* libraryname, bool global) {
   void* handle;
 
   // Try with the system library prefix and extension instead.
@@ -73,7 +73,7 @@ void* Os::loadLibrary(const char* libraryname) {
 #endif
   }
 
-  handle = Os::loadLibrary_(libraryname);
+  handle = Os::loadLibrary_(libraryname, global);
   if (handle != NULL) {
     return handle;
   }
@@ -96,7 +96,7 @@ void* Os::loadLibrary(const char* libraryname) {
   }
   str.append(Os::libraryExtension());
 
-  handle = Os::loadLibrary_(str.c_str());
+  handle = Os::loadLibrary_(str.c_str(), global);
   if (handle != NULL || str.find(fileSeparator()) != std::string::npos) {
     return handle;
   }

--- a/os/os.hpp
+++ b/os/os.hpp
@@ -135,7 +135,7 @@ class Os : AllStatic {
 
  private:
   //! Load the shared library named by \a filename
-  static void* loadLibrary_(const char* filename);
+  static void* loadLibrary_(const char* filename, bool global);
 
  public:
   //! Initialize the Os package.
@@ -280,7 +280,8 @@ class Os : AllStatic {
   typedef bool (*SymbolCallback)(std::string, const void*, void*);
 
   //! Load the shared library named by \a filename
-  static void* loadLibrary(const char* filename);
+  static void* loadLibrary(const char* filename, bool global=false);
+  
   //! Unload the shared library.
   static void unloadLibrary(void* handle);
   //! Return the address of the function identified by \a name.

--- a/os/os_posix.cpp
+++ b/os/os_posix.cpp
@@ -174,8 +174,10 @@ static void __exit() { Os::tearDown(); }
 
 void Os::tearDown() { Thread::tearDown(); }
 
-void* Os::loadLibrary_(const char* filename) {
-  return (*filename == '\0') ? NULL : ::dlopen(filename, RTLD_LAZY);
+void* Os::loadLibrary_(const char* filename, bool global) {
+  int flags = RTLD_LAZY;
+  if (global) flags |= RTLD_GLOBAL;
+  return (*filename == '\0') ? NULL : ::dlopen(filename, flags);
 }
 
 void Os::unloadLibrary(void* handle) { ::dlclose(handle); }

--- a/os/os_win32.cpp
+++ b/os/os_win32.cpp
@@ -97,7 +97,7 @@ __declspec(allocate(".CRT$XTU")) void (*__exit)(void) = Os::tearDown;
 
 void Os::tearDown() { Thread::tearDown(); }
 
-void* Os::loadLibrary_(const char* filename) {
+void* Os::loadLibrary_(const char* filename, bool global) {
   if (filename != NULL) {
     HMODULE hModule = ::LoadLibrary(filename);
     return hModule;


### PR DESCRIPTION
Ideally should also be forward/backported to other relevant ROCM versions.

HIPRtc currently does not correctly support LLVM plugins. Specifically, symbols defined within LLVM and/or clang are not available by any plugins when they are loaded. This is partially due to the fact that the one location with these symbols (libamd_comgr) does not mark these symbols as being available globally when it is loaded.

This patch is the first of two pieces required to support LLVM plugins on ROCm, the second of which is a change to ensure libamd_comgr marks LLVM/Clang symbols as exported for when it loads the plugin (https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/pull/43).

cc @jedbrown @LeilaGhaffari